### PR TITLE
百技第8组 第二题 

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/CacheData.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CacheData.java
@@ -11,8 +11,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CopyOnWriteArrayList;
-import java.util.concurrent.atomic.AtomicInteger;
+
 
 /**
  * @program: rocketmq-all
@@ -30,7 +29,6 @@ public class CacheData {
     private final ConcurrentHashMap<String/*topic*/, MemoryDataWithIndex> dataMap = new ConcurrentHashMap<>();
 
 
-
     private final MemoryMessageStore memoryMessageStore;
 
     private HashMap<String/* topic-queueid */, Long/* index */> topicQueueTable = new HashMap<String, Long>(1024);
@@ -38,9 +36,6 @@ public class CacheData {
     private final PutMessageLock putMessageLock;
 
     private volatile long beginTimeInLock = 0;
-
-
-
 
 
     public CacheData(final MemoryMessageStore memoryMessageStore) {
@@ -87,7 +82,7 @@ public class CacheData {
             MemoryDataWithIndex memoryDataWithIndex = dataMap.get(msg.getTopic());
 
             if (memoryDataWithIndex == null) {
-                dataMap.put(msg.getTopic(),new MemoryDataWithIndex());
+                dataMap.put(msg.getTopic(), new MemoryDataWithIndex());
                 memoryDataWithIndex = dataMap.get(msg.getTopic());
             }
 
@@ -104,7 +99,7 @@ public class CacheData {
             log.warn("[NOTIFYME]putMessage in lock cost time(ms)={}, bodyLength={} AppendMessageResult={}", eclipseTimeInLock, msg.getBody().length, result);
         }
 
-        result = new AppendMessageResult(AppendMessageStatus.PUT_OK, 0, msg.getBody()==null?0:msg.getBody().length, msg.getMsgId(), msg.getStoreTimestamp(), 0, 0);
+        result = new AppendMessageResult(AppendMessageStatus.PUT_OK, 0, msg.getBody() == null ? 0 : msg.getBody().length, msg.getMsgId(), msg.getStoreTimestamp(), 0, 0);
 
         PutMessageResult putMessageResult = new PutMessageResult(PutMessageStatus.PUT_OK, result);
 
@@ -132,7 +127,7 @@ public class CacheData {
 
     public long getMaxOffset(String topic) {
 
-        return dataMap.get(topic)==null?0:dataMap.get(topic).getNextIndex().get()-1;
+        return dataMap.get(topic) == null ? 0 : dataMap.get(topic).getNextIndex().get() - 1;
 
     }
 
@@ -146,21 +141,17 @@ public class CacheData {
         List<SelectMappedBufferResult> results = new ArrayList<>();
 
 
-
-        for (long i = offset; i < offset+maxMsgNums; i++) {
+        for (long i = offset; i < offset + maxMsgNums; i++) {
             if (i >= dataWithIndex.getNextIndex().get()) {
                 break;
             }
 
             MessageExtBrokerInner message = dataWithIndex.getMessage((int) i);
-            SelectMappedBufferResult result = new SelectMappedBufferResult(i,message.getBody()==null?null: ByteBuffer.wrap(message.getBody()),0,null);
+            SelectMappedBufferResult result = new SelectMappedBufferResult(i, message.getBody() == null ? null : ByteBuffer.wrap(message.getBody()), 0, null);
             results.add(result);
 
         }
 
         return results;
-
-
-
     }
 }

--- a/store/src/main/java/org/apache/rocketmq/store/CacheData.java
+++ b/store/src/main/java/org/apache/rocketmq/store/CacheData.java
@@ -1,0 +1,166 @@
+package org.apache.rocketmq.store;
+
+import org.apache.rocketmq.common.UtilAll;
+import org.apache.rocketmq.common.constant.LoggerName;
+import org.apache.rocketmq.common.sysflag.MessageSysFlag;
+import org.apache.rocketmq.logging.InternalLogger;
+import org.apache.rocketmq.logging.InternalLoggerFactory;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @program: rocketmq-all
+ * @description: 内存数据缓存
+ * @author: xdCao
+ * @create: 2018-08-20 18:26
+ **/
+public class CacheData {
+
+    private static final InternalLogger log = InternalLoggerFactory.getLogger(LoggerName.STORE_LOGGER_NAME);
+
+    private final ThreadLocal<CommitLog.MessageExtBatchEncoder> batchEncoderThreadLocal;
+
+
+    private final ConcurrentHashMap<String/*topic*/, MemoryDataWithIndex> dataMap = new ConcurrentHashMap<>();
+
+
+
+    private final MemoryMessageStore memoryMessageStore;
+
+    private HashMap<String/* topic-queueid */, Long/* index */> topicQueueTable = new HashMap<String, Long>(1024);
+
+    private final PutMessageLock putMessageLock;
+
+    private volatile long beginTimeInLock = 0;
+
+
+
+
+
+    public CacheData(final MemoryMessageStore memoryMessageStore) {
+        this.memoryMessageStore = memoryMessageStore;
+        this.putMessageLock = memoryMessageStore.getMessageStoreConfig().isUseReentrantLockWhenPutMessage() ? new PutMessageReentrantLock() : new PutMessageSpinLock();
+        batchEncoderThreadLocal = new ThreadLocal<CommitLog.MessageExtBatchEncoder>() {
+            @Override
+            protected CommitLog.MessageExtBatchEncoder initialValue() {
+                return new CommitLog.MessageExtBatchEncoder(memoryMessageStore.getMessageStoreConfig().getMaxMessageSize());
+            }
+        };
+    }
+
+
+    public PutMessageResult putMessage(final MessageExtBrokerInner msg) {
+        msg.setStoreTimestamp(System.currentTimeMillis());
+        msg.setBodyCRC(UtilAll.crc32(msg.getBody()));
+
+        AppendMessageResult result = null;
+
+        StoreStatsService storeStatsService = this.memoryMessageStore.getStoreStatsService();
+
+        String topic = msg.getTopic();
+        int queueId = msg.getQueueId();
+
+        final int tranType = MessageSysFlag.getTransactionValue(msg.getSysFlag());
+        if (tranType == MessageSysFlag.TRANSACTION_NOT_TYPE
+                || tranType == MessageSysFlag.TRANSACTION_COMMIT_TYPE) {
+            // Delay Delivery 不支持延时消息,因为延时消息和defaultMessageStore高耦合
+
+        }
+
+        long eclipseTimeInLock = 0;
+
+        putMessageLock.lock(); //spin or ReentrantLock ,depending on store config
+        try {
+            long beginLockTimestamp = this.memoryMessageStore.getSystemClock().now();
+            this.beginTimeInLock = beginLockTimestamp;
+
+            // Here settings are stored timestamp, in order to ensure an orderly
+            // global
+            msg.setStoreTimestamp(beginLockTimestamp);
+
+            MemoryDataWithIndex memoryDataWithIndex = dataMap.get(msg.getTopic());
+
+            if (memoryDataWithIndex == null) {
+                dataMap.put(msg.getTopic(),new MemoryDataWithIndex());
+                memoryDataWithIndex = dataMap.get(msg.getTopic());
+            }
+
+            memoryDataWithIndex.putMessage(msg);
+
+
+            eclipseTimeInLock = this.memoryMessageStore.getSystemClock().now() - beginLockTimestamp;
+            beginTimeInLock = 0;
+        } finally {
+            putMessageLock.unlock();
+        }
+
+        if (eclipseTimeInLock > 500) {
+            log.warn("[NOTIFYME]putMessage in lock cost time(ms)={}, bodyLength={} AppendMessageResult={}", eclipseTimeInLock, msg.getBody().length, result);
+        }
+
+        result = new AppendMessageResult(AppendMessageStatus.PUT_OK, 0, msg.getBody()==null?0:msg.getBody().length, msg.getMsgId(), msg.getStoreTimestamp(), 0, 0);
+
+        PutMessageResult putMessageResult = new PutMessageResult(PutMessageStatus.PUT_OK, result);
+
+        // Statistics
+        storeStatsService.getSinglePutMessageTopicTimesTotal(msg.getTopic()).incrementAndGet();
+        storeStatsService.getSinglePutMessageTopicSizeTotal(topic).addAndGet(result.getWroteBytes());
+
+        /*暂时先不支持事务*/
+//        handleHA(result, putMessageResult, msg);
+
+        return putMessageResult;
+    }
+
+
+    public MessageExtBrokerInner getMessage(String topic, int offset) {
+
+        if (dataMap.get(topic) == null) {
+            return null;
+        }
+
+        return dataMap.get(topic).getMessage(offset);
+
+    }
+
+
+    public long getMaxOffset(String topic) {
+
+        return dataMap.get(topic)==null?0:dataMap.get(topic).getNextIndex().get()-1;
+
+    }
+
+    public List<SelectMappedBufferResult> getMessagesFromOffset(String topic, long offset, int maxMsgNums) {
+
+        MemoryDataWithIndex dataWithIndex = dataMap.get(topic);
+        if (dataWithIndex == null || offset >= dataWithIndex.getNextIndex().get()) {
+            return null;
+        }
+
+        List<SelectMappedBufferResult> results = new ArrayList<>();
+
+
+
+        for (long i = offset; i < offset+maxMsgNums; i++) {
+            if (i >= dataWithIndex.getNextIndex().get()) {
+                break;
+            }
+
+            MessageExtBrokerInner message = dataWithIndex.getMessage((int) i);
+            SelectMappedBufferResult result = new SelectMappedBufferResult(i,message.getBody()==null?null: ByteBuffer.wrap(message.getBody()),0,null);
+            results.add(result);
+
+        }
+
+        return results;
+
+
+
+    }
+}

--- a/store/src/main/java/org/apache/rocketmq/store/MemoryDataWithIndex.java
+++ b/store/src/main/java/org/apache/rocketmq/store/MemoryDataWithIndex.java
@@ -1,0 +1,55 @@
+package org.apache.rocketmq.store;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * @program: rocketmq-all
+ * @description:
+ * @author: xdCao
+ * @create: 2018-08-20 20:37
+ **/
+public class MemoryDataWithIndex {
+
+    private AtomicInteger nextIndex = new AtomicInteger(0);
+
+    private List<MessageExtBrokerInner> dataList = new ArrayList<>(32);
+
+    public MemoryDataWithIndex() {
+    }
+
+    public MessageExtBrokerInner getMessage () {
+        return dataList.get(nextIndex.getAndIncrement());
+    }
+
+    public MessageExtBrokerInner getMessage (Integer offset) {
+        if (offset >= dataList.size()) {
+            return null;
+        }
+        return dataList.get(offset);
+    }
+
+
+    public synchronized void putMessage(MessageExtBrokerInner msg) {
+        dataList.add(msg);
+        nextIndex.incrementAndGet();
+    }
+
+
+    public AtomicInteger getNextIndex() {
+        return nextIndex;
+    }
+
+    public void setNextIndex(AtomicInteger nextIndex) {
+        this.nextIndex = nextIndex;
+    }
+
+    public List<MessageExtBrokerInner> getDataList() {
+        return dataList;
+    }
+
+    public void setDataList(List<MessageExtBrokerInner> dataList) {
+        this.dataList = dataList;
+    }
+}

--- a/store/src/main/java/org/apache/rocketmq/store/MemoryMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/MemoryMessageStore.java
@@ -61,6 +61,7 @@ public class MemoryMessageStore implements MessageStore {
 
     public MemoryMessageStore(final MessageStoreConfig messageStoreConfig, final BrokerStatsManager brokerStatsManager,
                               final BrokerConfig brokerConfig) throws FileNotFoundException {
+
         this.messageStoreConfig = messageStoreConfig;
         this.brokerConfig = brokerConfig;
         this.brokerStatsManager = brokerStatsManager;
@@ -239,29 +240,28 @@ public class MemoryMessageStore implements MessageStore {
 
     @Override
     public long getMaxOffsetInQueue(String topic, int queueId) {
-        return 0;
+        return cacheData.getMaxOffset(topic);
     }
 
     @Override
     public long getMinOffsetInQueue(String topic, int queueId) {
-        return 0;
+        return cacheData.getMinOffset(topic);
     }
 
     @Override
     public long getCommitLogOffsetInQueue(String topic, int queueId, long consumeQueueOffset) {
-        return 0;
-    }
-
-    @Override
-    public long getOffsetInQueueByTime(String topic, int queueId, long timestamp) {
-        return 0;
+        return cacheData.getCommitLogOffsetInQueue(topic, consumeQueueOffset);
     }
 
     @Override
     public MessageExt lookMessageByOffset(long commitLogOffset) {
-        return null;
+        return cacheData.lookMessageByOffset(commitLogOffset);
     }
 
+    @Override
+    public SelectMappedBufferResult getCommitLogData(long offset) {
+        return cacheData.getCommitLogData(offset);
+    }
 
     public MessageStoreConfig getMessageStoreConfig() {
 
@@ -275,6 +275,12 @@ public class MemoryMessageStore implements MessageStore {
 
     public StoreStatsService getStoreStatsService() {
         return storeStatsService;
+    }
+
+
+    @Override
+    public long getOffsetInQueueByTime(String topic, int queueId, long timestamp) {
+        return 0;
     }
 
     @Override
@@ -327,10 +333,6 @@ public class MemoryMessageStore implements MessageStore {
         return 0;
     }
 
-    @Override
-    public SelectMappedBufferResult getCommitLogData(long offset) {
-        return null;
-    }
 
     @Override
     public boolean appendToCommitLog(long startOffset, byte[] data) {

--- a/store/src/main/java/org/apache/rocketmq/store/MemoryMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/MemoryMessageStore.java
@@ -1,0 +1,440 @@
+package org.apache.rocketmq.store;
+
+import org.apache.rocketmq.common.BrokerConfig;
+import org.apache.rocketmq.common.SystemClock;
+import org.apache.rocketmq.common.constant.LoggerName;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.common.message.MessageExtBatch;
+import org.apache.rocketmq.logging.InternalLogger;
+import org.apache.rocketmq.logging.InternalLoggerFactory;
+import org.apache.rocketmq.store.config.BrokerRole;
+import org.apache.rocketmq.store.config.MessageStoreConfig;
+import org.apache.rocketmq.store.config.StorePathConfigHelper;
+import org.apache.rocketmq.store.schedule.ScheduleMessageService;
+import org.apache.rocketmq.store.stats.BrokerStatsManager;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.channels.FileLock;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static org.apache.rocketmq.store.config.BrokerRole.SLAVE;
+
+/**
+ * @program: rocketmq-all
+ * @description: 不带持久化的store实现
+ * @author: xdCao
+ * @create: 2018-08-20 18:24
+ **/
+public class MemoryMessageStore implements MessageStore {
+
+    private static final InternalLogger log = InternalLoggerFactory.getLogger(LoggerName.STORE_LOGGER_NAME);
+
+    private final MessageStoreConfig messageStoreConfig;
+
+    private final CacheData cacheData;
+
+    private final SystemClock systemClock = new SystemClock();
+
+    private final StoreStatsService storeStatsService;
+
+    private volatile boolean shutdown = true;
+
+    private final BrokerConfig brokerConfig;
+
+    private final BrokerStatsManager brokerStatsManager;
+
+    private RandomAccessFile lockFile;
+
+    private FileLock lock;
+
+    private final MessageArrivingListener messageArrivingListener;
+
+    private AtomicLong printTimes = new AtomicLong(0);
+
+    boolean shutDownNormal = false;
+
+
+    private final RunningFlags runningFlags = new RunningFlags();
+
+
+    public MemoryMessageStore(final MessageStoreConfig messageStoreConfig, final BrokerStatsManager brokerStatsManager,
+                              final MessageArrivingListener messageArrivingListener, final BrokerConfig brokerConfig) throws FileNotFoundException {
+        this.messageStoreConfig = messageStoreConfig;
+        this.cacheData = new CacheData(this);
+        this.messageArrivingListener = messageArrivingListener;
+        this.brokerConfig = brokerConfig;
+        this.brokerStatsManager = brokerStatsManager;
+        this.storeStatsService = new StoreStatsService();
+
+
+        File file = new File(StorePathConfigHelper.getLockFile(messageStoreConfig.getStorePathRootDir()));
+        MappedFile.ensureDirOK(file.getParent());
+        lockFile = new RandomAccessFile(file, "rw");
+
+    }
+
+    @Override
+    public boolean load() {
+        return true;
+    }
+
+
+    @Override
+    public void start() throws Exception {
+        lock = lockFile.getChannel().tryLock(0, 1, false);
+        if (lock == null || lock.isShared() || !lock.isValid()) {
+            throw new RuntimeException("Lock failed,MQ already started");
+        }
+
+        lockFile.getChannel().write(ByteBuffer.wrap("lock".getBytes()));
+        lockFile.getChannel().force(true);
+
+        this.storeStatsService.start();
+
+        this.shutdown = false;
+    }
+
+    @Override
+    public void shutdown() {
+
+        if (!this.shutdown) {
+            this.shutdown = true;
+
+            try {
+
+                Thread.sleep(1000);
+            } catch (InterruptedException e) {
+                log.error("shutdown Exception, ", e);
+            }
+
+            this.storeStatsService.shutdown();
+
+            if (this.runningFlags.isWriteable() && dispatchBehindBytes() == 0) {
+                this.deleteFile(StorePathConfigHelper.getAbortFile(this.messageStoreConfig.getStorePathRootDir()));
+                shutDownNormal = true;
+            } else {
+                log.warn("the store may be wrong, so shutdown abnormally, and keep abort file.");
+            }
+        }
+
+        if (lockFile != null && lock != null) {
+            try {
+                lock.release();
+                lockFile.close();
+            } catch (IOException e) {
+            }
+        }
+    }
+
+    @Override
+    public void destroy() {
+        this.deleteFile(StorePathConfigHelper.getAbortFile(this.messageStoreConfig.getStorePathRootDir()));
+        this.deleteFile(StorePathConfigHelper.getStoreCheckpoint(this.messageStoreConfig.getStorePathRootDir()));
+    }
+
+
+    private void deleteFile(final String fileName) {
+        File file = new File(fileName);
+        boolean result = file.delete();
+        log.info(fileName + (result ? " delete OK" : " delete Failed"));
+    }
+
+    @Override
+    public PutMessageResult putMessage(MessageExtBrokerInner msg) {
+        if (this.shutdown) {
+            log.warn("message store has shutdown, so putMessage is forbidden");
+            return new PutMessageResult(PutMessageStatus.SERVICE_NOT_AVAILABLE, null);
+        }
+
+        if (BrokerRole.SLAVE == this.messageStoreConfig.getBrokerRole()) {
+            long value = this.printTimes.getAndIncrement();
+            if ((value % 50000) == 0) {
+                log.warn("message store is slave mode, so putMessage is forbidden ");
+            }
+
+            return new PutMessageResult(PutMessageStatus.SERVICE_NOT_AVAILABLE, null);
+        }
+
+        if (!this.runningFlags.isWriteable()) {
+            long value = this.printTimes.getAndIncrement();
+            if ((value % 50000) == 0) {
+                log.warn("message store is not writeable, so putMessage is forbidden " + this.runningFlags.getFlagBits());
+            }
+
+            return new PutMessageResult(PutMessageStatus.SERVICE_NOT_AVAILABLE, null);
+        } else {
+            this.printTimes.set(0);
+        }
+
+        if (msg.getTopic().length() > Byte.MAX_VALUE) {
+            log.warn("putMessage message topic length too long " + msg.getTopic().length());
+            return new PutMessageResult(PutMessageStatus.MESSAGE_ILLEGAL, null);
+        }
+
+        if (msg.getPropertiesString() != null && msg.getPropertiesString().length() > Short.MAX_VALUE) {
+            log.warn("putMessage message properties length too long " + msg.getPropertiesString().length());
+            return new PutMessageResult(PutMessageStatus.PROPERTIES_SIZE_EXCEEDED, null);
+        }
+
+        if (this.isOSPageCacheBusy()) {
+            return new PutMessageResult(PutMessageStatus.OS_PAGECACHE_BUSY, null);
+        }
+
+        long beginTime = this.getSystemClock().now();
+
+        PutMessageResult result = this.cacheData.putMessage(msg);
+
+        long eclipseTime = this.getSystemClock().now() - beginTime;
+        if (eclipseTime > 500) {
+            log.warn("putMessage not in lock eclipse time(ms)={}, bodyLength={}", eclipseTime, msg.getBody().length);
+        }
+        this.storeStatsService.setPutMessageEntireTimeMax(eclipseTime);
+
+        if (null == result || !result.isOk()) {
+            this.storeStatsService.getPutMessageFailedTimes().incrementAndGet();
+        }
+
+        return result;
+    }
+
+
+    @Override
+    public PutMessageResult putMessages(MessageExtBatch messageExtBatch) {
+        return null;
+    }
+
+    @Override
+    public GetMessageResult getMessage(String group, String topic, int queueId, long offset, int maxMsgNums, MessageFilter messageFilter) {
+
+        if (this.shutdown) {
+            log.warn("message store has shutdown, so getMessage is forbidden");
+            return null;
+        }
+
+        if (!this.runningFlags.isReadable()) {
+            log.warn("message store is not readable, so getMessage is forbidden " + this.runningFlags.getFlagBits());
+            return null;
+        }
+
+        GetMessageResult getMessageResult = new GetMessageResult();
+
+        List<SelectMappedBufferResult> results = cacheData.getMessagesFromOffset(topic, offset, maxMsgNums);
+
+        if (results == null || results.size() == 0) {
+            getMessageResult.setStatus(GetMessageStatus.NO_MATCHED_MESSAGE);
+            return getMessageResult;
+        }
+
+        getMessageResult.setStatus(GetMessageStatus.FOUND);
+        for (SelectMappedBufferResult result : results) {
+            getMessageResult.addMessage(result);
+        }
+        getMessageResult.setBufferTotalSize(results.size());
+
+        return getMessageResult;
+
+    }
+
+
+    @Override
+    public long getMaxOffsetInQueue(String topic, int queueId) {
+        return 0;
+    }
+
+    @Override
+    public long getMinOffsetInQueue(String topic, int queueId) {
+        return 0;
+    }
+
+    @Override
+    public long getCommitLogOffsetInQueue(String topic, int queueId, long consumeQueueOffset) {
+        return 0;
+    }
+
+    @Override
+    public long getOffsetInQueueByTime(String topic, int queueId, long timestamp) {
+        return 0;
+    }
+
+    @Override
+    public MessageExt lookMessageByOffset(long commitLogOffset) {
+        return null;
+    }
+
+
+    public MessageStoreConfig getMessageStoreConfig() {
+
+        return messageStoreConfig;
+
+    }
+
+    public SystemClock getSystemClock() {
+        return systemClock;
+    }
+
+    public StoreStatsService getStoreStatsService() {
+        return storeStatsService;
+    }
+
+    @Override
+    public SelectMappedBufferResult selectOneMessageByOffset(long commitLogOffset) {
+        return null;
+    }
+
+    @Override
+    public SelectMappedBufferResult selectOneMessageByOffset(long commitLogOffset, int msgSize) {
+        return null;
+    }
+
+    @Override
+    public String getRunningDataInfo() {
+        return null;
+    }
+
+    @Override
+    public HashMap<String, String> getRuntimeInfo() {
+        return null;
+    }
+
+    @Override
+    public long getMaxPhyOffset() {
+        return 0;
+    }
+
+    @Override
+    public long getMinPhyOffset() {
+        return 0;
+    }
+
+    @Override
+    public long getEarliestMessageTime(String topic, int queueId) {
+        return 0;
+    }
+
+    @Override
+    public long getEarliestMessageTime() {
+        return 0;
+    }
+
+    @Override
+    public long getMessageStoreTimeStamp(String topic, int queueId, long consumeQueueOffset) {
+        return 0;
+    }
+
+    @Override
+    public long getMessageTotalInQueue(String topic, int queueId) {
+        return 0;
+    }
+
+    @Override
+    public SelectMappedBufferResult getCommitLogData(long offset) {
+        return null;
+    }
+
+    @Override
+    public boolean appendToCommitLog(long startOffset, byte[] data) {
+        return false;
+    }
+
+    @Override
+    public void executeDeleteFilesManually() {
+
+    }
+
+    @Override
+    public QueryMessageResult queryMessage(String topic, String key, int maxNum, long begin, long end) {
+        return null;
+    }
+
+    @Override
+    public void updateHaMasterAddress(String newAddr) {
+
+    }
+
+    @Override
+    public long slaveFallBehindMuch() {
+        return 0;
+    }
+
+    @Override
+    public long now() {
+        return 0;
+    }
+
+    @Override
+    public int cleanUnusedTopic(Set<String> topics) {
+        return 0;
+    }
+
+    @Override
+    public void cleanExpiredConsumerQueue() {
+
+    }
+
+    @Override
+    public boolean checkInDiskByConsumeOffset(String topic, int queueId, long consumeOffset) {
+        return false;
+    }
+
+    @Override
+    public long dispatchBehindBytes() {
+        return 0;
+    }
+
+    @Override
+    public long flush() {
+        return 0;
+    }
+
+    @Override
+    public boolean resetWriteOffset(long phyOffset) {
+        return false;
+    }
+
+    @Override
+    public long getConfirmOffset() {
+        return 0;
+    }
+
+    @Override
+    public void setConfirmOffset(long phyOffset) {
+
+    }
+
+    @Override
+    public boolean isOSPageCacheBusy() {
+        return false;
+    }
+
+    @Override
+    public long lockTimeMills() {
+        return 0;
+    }
+
+    @Override
+    public boolean isTransientStorePoolDeficient() {
+        return false;
+    }
+
+    @Override
+    public LinkedList<CommitLogDispatcher> getDispatcherList() {
+        return null;
+    }
+
+    @Override
+    public ConsumeQueue getConsumeQueue(String topic, int queueId) {
+        return null;
+    }
+
+
+}

--- a/store/src/test/java/org/apache/rocketmq/store/MemoryMessageStoreTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/MemoryMessageStoreTest.java
@@ -22,7 +22,7 @@ import static org.junit.Assert.assertTrue;
 
 /**
  * @program: rocketmq-all
- * @description:
+ * @description:测试非持久化broker
  * @author: xdCao
  * @create: 2018-08-20 20:57
  **/
@@ -58,7 +58,7 @@ public class MemoryMessageStoreTest {
         messageStoreConfig.setMapedFileSizeConsumeQueue(1024 * 4);
         messageStoreConfig.setMaxHashSlotNum(100);
         messageStoreConfig.setMaxIndexNum(100 * 10);
-        MessageStore master = new MemoryMessageStore(messageStoreConfig, null, new MemoryMessageStoreTest.MyMessageArrivingListener(), new BrokerConfig());
+        MessageStore master = new MemoryMessageStore(messageStoreConfig, null, new BrokerConfig());
 
         boolean load = master.load();
         assertTrue(load);
@@ -90,7 +90,7 @@ public class MemoryMessageStoreTest {
         messageStoreConfig.setMaxIndexNum(100 * 100);
         messageStoreConfig.setFlushDiskType(FlushDiskType.SYNC_FLUSH);
         messageStoreConfig.setFlushIntervalConsumeQueue(1);
-        return new MemoryMessageStore(messageStoreConfig, new BrokerStatsManager("simpleTest"), new MemoryMessageStoreTest.MyMessageArrivingListener(), new BrokerConfig());
+        return new MemoryMessageStore(messageStoreConfig, new BrokerStatsManager("simpleTest"), new BrokerConfig());
     }
 
     @Test

--- a/store/src/test/java/org/apache/rocketmq/store/MemoryMessageStoreTest.java
+++ b/store/src/test/java/org/apache/rocketmq/store/MemoryMessageStoreTest.java
@@ -1,0 +1,172 @@
+package org.apache.rocketmq.store;
+
+import org.apache.rocketmq.common.BrokerConfig;
+import org.apache.rocketmq.common.UtilAll;
+import org.apache.rocketmq.store.config.FlushDiskType;
+import org.apache.rocketmq.store.config.MessageStoreConfig;
+import org.apache.rocketmq.store.stats.BrokerStatsManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.net.SocketAddress;
+import java.nio.channels.OverlappingFileLockException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * @program: rocketmq-all
+ * @description:
+ * @author: xdCao
+ * @create: 2018-08-20 20:57
+ **/
+public class MemoryMessageStoreTest {
+
+
+    private final String StoreMessage = "Once, there was a chance for me!";
+    private int QUEUE_TOTAL = 100;
+    private AtomicInteger QueueId = new AtomicInteger(0);
+    private SocketAddress BornHost;
+    private SocketAddress StoreHost;
+    private byte[] MessageBody;
+    private MessageStore messageStore;
+
+    @Before
+    public void init() throws Exception {
+        StoreHost = new InetSocketAddress(InetAddress.getLocalHost(), 8123);
+        BornHost = new InetSocketAddress(InetAddress.getByName("127.0.0.1"), 0);
+
+        messageStore = buildMessageStore();
+        boolean load = messageStore.load();
+        assertTrue(load);
+        messageStore.start();
+    }
+
+    @Test(expected = OverlappingFileLockException.class)
+    public void test_repate_restart() throws Exception {
+        QUEUE_TOTAL = 1;
+        MessageBody = StoreMessage.getBytes();
+
+        MessageStoreConfig messageStoreConfig = new MessageStoreConfig();
+        messageStoreConfig.setMapedFileSizeCommitLog(1024 * 8);
+        messageStoreConfig.setMapedFileSizeConsumeQueue(1024 * 4);
+        messageStoreConfig.setMaxHashSlotNum(100);
+        messageStoreConfig.setMaxIndexNum(100 * 10);
+        MessageStore master = new MemoryMessageStore(messageStoreConfig, null, new MemoryMessageStoreTest.MyMessageArrivingListener(), new BrokerConfig());
+
+        boolean load = master.load();
+        assertTrue(load);
+
+        try {
+            master.start();
+            master.start();
+        } finally {
+            master.shutdown();
+            master.destroy();
+        }
+    }
+
+    @After
+    public void destory() {
+        messageStore.shutdown();
+        messageStore.destroy();
+
+        MessageStoreConfig messageStoreConfig = new MessageStoreConfig();
+        File file = new File(messageStoreConfig.getStorePathRootDir());
+        UtilAll.deleteFile(file);
+    }
+
+    private MessageStore buildMessageStore() throws Exception {
+        MessageStoreConfig messageStoreConfig = new MessageStoreConfig();
+        messageStoreConfig.setMapedFileSizeCommitLog(1024 * 1024 * 10);
+        messageStoreConfig.setMapedFileSizeConsumeQueue(1024 * 1024 * 10);
+        messageStoreConfig.setMaxHashSlotNum(10000);
+        messageStoreConfig.setMaxIndexNum(100 * 100);
+        messageStoreConfig.setFlushDiskType(FlushDiskType.SYNC_FLUSH);
+        messageStoreConfig.setFlushIntervalConsumeQueue(1);
+        return new MemoryMessageStore(messageStoreConfig, new BrokerStatsManager("simpleTest"), new MemoryMessageStoreTest.MyMessageArrivingListener(), new BrokerConfig());
+    }
+
+    @Test
+    public void testWriteAndRead() {
+        long totalMsgs = 10;
+        QUEUE_TOTAL = 1;
+        MessageBody = StoreMessage.getBytes();
+        for (long i = 0; i < totalMsgs; i++) {
+            messageStore.putMessage(buildMessage());
+        }
+
+        for (long i = 0; i < totalMsgs; i++) {
+            GetMessageResult result = messageStore.getMessage("GROUP_A", "TOPIC_A", 0, i, 1024 * 1024, null);
+            assertThat(result).isNotNull();
+            result.release();
+        }
+        verifyThatMasterIsFunctional(totalMsgs, messageStore);
+    }
+
+    private MessageExtBrokerInner buildMessage() {
+        MessageExtBrokerInner msg = new MessageExtBrokerInner();
+        msg.setTopic("FooBar");
+        msg.setTags("TAG1");
+        msg.setKeys("Hello");
+        msg.setBody(MessageBody);
+        msg.setKeys(String.valueOf(System.currentTimeMillis()));
+        msg.setQueueId(Math.abs(QueueId.getAndIncrement()) % QUEUE_TOTAL);
+        msg.setSysFlag(0);
+        msg.setBornTimestamp(System.currentTimeMillis());
+        msg.setStoreHost(StoreHost);
+        msg.setBornHost(BornHost);
+        return msg;
+    }
+
+    private void verifyThatMasterIsFunctional(long totalMsgs, MessageStore master) {
+        for (long i = 0; i < totalMsgs; i++) {
+            master.putMessage(buildMessage());
+        }
+
+        for (long i = 0; i < totalMsgs; i++) {
+            GetMessageResult result = master.getMessage("GROUP_A", "TOPIC_A", 0, i, 1024 * 1024, null);
+            assertThat(result).isNotNull();
+            result.release();
+
+        }
+    }
+
+    @Test
+    public void testPullSize() throws Exception {
+        String topic = "pullSizeTopic";
+
+        for (int i = 0; i < 32; i++) {
+            MessageExtBrokerInner messageExtBrokerInner = buildMessage();
+            messageExtBrokerInner.setTopic(topic);
+            messageExtBrokerInner.setQueueId(0);
+            messageStore.putMessage(messageExtBrokerInner);
+        }
+        // wait for consume queue build
+        // the sleep time should be great than consume queue flush interval
+        Thread.sleep(100);
+        String group = "simple";
+        GetMessageResult getMessageResult32 = messageStore.getMessage(group, topic, 0, 0, 32, null);
+        assertThat(getMessageResult32.getMessageBufferList().size()).isEqualTo(32);
+
+        GetMessageResult getMessageResult20 = messageStore.getMessage(group, topic, 0, 0, 20, null);
+        assertThat(getMessageResult20.getMessageBufferList().size()).isEqualTo(20);
+
+        GetMessageResult getMessageResult45 = messageStore.getMessage(group, topic, 0, 0, 10, null);
+        assertThat(getMessageResult45.getMessageBufferList().size()).isEqualTo(10);
+    }
+
+    private class MyMessageArrivingListener implements MessageArrivingListener {
+        @Override
+        public void arriving(String topic, int queueId, long logicOffset, long tagsCode, long msgStoreTime,
+                             byte[] filterBitMap, Map<String, String> properties) {
+        }
+    }
+
+}


### PR DESCRIPTION
## 题目：为RocketMQ提供非持久化的Broker

fix issure #1 

## Brief changelog

考虑基于内存缓存来做非持久化的broker，起初的想法是直接不要类似于commitLog的线性的物理结构，直接采用Map<String/*topic*/,List<MsgData>>的形式进行存储，这样方便直接根据topic查找数据，并且由于是在内存中，不需要进行逻辑队列-》物理队列的查找，但是由于接口的限制，需要实现很多偏移量相关的接口，因此一个线性的数据存储结构是必须的。所以现在使用一个List来存储消息实体，再使用一个Map<String,List<Integer>>存储Topic和其中的消息的offset的对应关系,来记录消息数据的偏移量。


由于时间仓促，且对rocketMQ的了解不够，broker是一个牵涉东西比较复杂的模块，很多特性都没有去考虑，像HA，故障重试等等，只是实现了一个简单的数据存取。