### PR TITLE
【百技 第2组 第3题】全局排序consumer

### DIFF
--- a/example/src/main/java/org/apache/rocketmq/example/quickstart/ConsumerOrderly.java
+++ b/example/src/main/java/org/apache/rocketmq/example/quickstart/ConsumerOrderly.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.apache.rocketmq.example.quickstart;
 
 import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
@@ -10,15 +27,79 @@ import org.apache.rocketmq.common.message.MessageExt;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
+import java.util.Comparator;
+import java.util.PriorityQueue;
 
+class LabeledMsg {
+    public MessageExt msg;
+    public int lstId;
+    public LabeledMsg(MessageExt msg, int lstId) {
+        this.msg = msg;
+        this.lstId = lstId;
+    }
+}
+class LabeledMsgComparator implements Comparator<LabeledMsg> {
+    public int compare(LabeledMsg l1, LabeledMsg l2) {
+        if (l1.msg.getStoreTimestamp() < l2.msg.getStoreTimestamp())
+            return 1;
+        else if (l1.msg.getStoreTimestamp() < l2.msg.getStoreTimestamp())
+            return -1;
+        else
+            return 0;
+    }
+}
 public class ConsumerOrderly {
-    List<MessageExt> messageNeedToCompare = new ArrayList<MessageExt>();
+    static ArrayList<MessageExt> messageNeedToCompare = new ArrayList<MessageExt>();
 
     // input: list of mps
     // return: message ready to print
-    public static List<MessageExt> sort(List<List<MessageExt>> mps){
-        // todo
+    public static ArrayList<MessageExt> sort(ArrayList<ArrayList<MessageExt>> mps) {
+        int sz = mps.size();
+        int[] listLen = new int[sz];
+        int[] idx = new int[sz];
+        ArrayList<MessageExt> ret = new ArrayList<MessageExt>();
+        PriorityQueue<LabeledMsg> pq = new PriorityQueue<LabeledMsg>(sz, new LabeledMsgComparator());
+
+        System.out.printf("Start sorting. %n");
+
+        for (int i = 0;i < sz;i++) {
+            idx[i] = 1;
+            listLen[i] = mps.get(i).size();
+            LabeledMsg tmp = new LabeledMsg(mps.get(i).get(0), i);
+            pq.add(tmp);
+        }
+
+        System.out.printf("Poll first finished. %n");
+
+        while (true) {
+            LabeledMsg tmp = pq.poll();
+            ret.add(tmp.msg);
+            int id = tmp.lstId;
+            if (idx[id] >= listLen[id])
+                break;
+            LabeledMsg addToPq = new LabeledMsg(mps.get(id).get(idx[id]), id);
+            idx[id] += 1;
+            pq.add(addToPq);
+        }
+
+        System.out.printf("Finish while. %n");
+
+        for (int i = 0;i < sz;i++) {
+            int curLen = listLen[i];
+            for (int j = idx[i];j < curLen;j++) {
+                LabeledMsg tmp = new LabeledMsg(mps.get(i).get(j), i);
+                pq.add(tmp);
+            }
+        }
+
+        System.out.printf("Poll last Finish %n");
+
+        while (!pq.isEmpty()) {
+            messageNeedToCompare.add(pq.poll().msg);
+        }
+
+        System.out.printf("Finish poll rest. %n");
+        return ret;
     }
 
     public static void main(String[] args) throws InterruptedException, MQClientException {
@@ -27,18 +108,12 @@ public class ConsumerOrderly {
          * Instantiate with specified consumer group name.
          */
         DefaultMQPushConsumer consumer = new DefaultMQPushConsumer("please_rename_unique_group_name_4");
-
-        /*
-         * Specify name server addresses.
-         * <p/>
-         *
-         * Alternatively, you may specify name server addresses via exporting environmental variable: NAMESRV_ADDR
-         * <pre>
-         * {@code
-         * consumer.setNamesrvAddr("name-server1-ip:9876;name-server2-ip:9876");
-         * }
-         * </pre>
-         */
+        consumer.setConsumeThreadMin(1);
+        consumer.setConsumeThreadMax(1);
+        consumer.setPullThresholdForQueue(1);
+        consumer.setPullThresholdForTopic(1);
+        consumer.setClientCallbackExecutorThreads(1);
+        consumer.setPersistConsumerOffsetInterval(10);
 
         /*
          * Specify where to start in case the specified consumer group is a brand new one.
@@ -58,7 +133,22 @@ public class ConsumerOrderly {
             @Override
             public ConsumeConcurrentlyStatus consumeMessage(List<MessageExt> msgs,
                                                             ConsumeConcurrentlyContext context) {
-                System.out.printf("%s Receive New Messages: %s %n", Thread.currentThread().getName(), msgs);
+                System.out.printf("Msg received. %n");
+                ArrayList<ArrayList<MessageExt>> mps = new ArrayList<ArrayList<MessageExt>>();
+                for (MessageExt msg: msgs) {
+                    if (msg.getQueueId() >= mps.size())
+                        mps.add(new ArrayList<MessageExt>());
+                    mps.get(msg.getQueueId()).add(msg);
+                }
+                System.out.printf("Preparation finished. %n");
+                List<MessageExt> res = sort(mps);
+                System.out.printf("Sort finished. %n");
+
+                System.out.printf("=======%s Start print msg results: %s %n ========", Thread.currentThread().getName(), res);
+                for (MessageExt msg: res){
+                    System.out.printf("Receive message with timestamp %d %n", msg.getStoreTimestamp());
+                }
+                System.out.printf("=======%s Receive New Messages: %s %n=======", Thread.currentThread().getName(), res);
                 return ConsumeConcurrentlyStatus.CONSUME_SUCCESS;
             }
         });

--- a/example/src/main/java/org/apache/rocketmq/example/quickstart/ConsumerOrderly.java
+++ b/example/src/main/java/org/apache/rocketmq/example/quickstart/ConsumerOrderly.java
@@ -1,0 +1,73 @@
+package org.apache.rocketmq.example.quickstart;
+
+import org.apache.rocketmq.client.consumer.DefaultMQPushConsumer;
+import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyContext;
+import org.apache.rocketmq.client.consumer.listener.ConsumeConcurrentlyStatus;
+import org.apache.rocketmq.client.consumer.listener.MessageListenerConcurrently;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.consumer.ConsumeFromWhere;
+import org.apache.rocketmq.common.message.MessageExt;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class ConsumerOrderly {
+    List<MessageExt> messageNeedToCompare = new ArrayList<MessageExt>();
+
+    // input: list of mps
+    // return: message ready to print
+    public static List<MessageExt> sort(List<List<MessageExt>> mps){
+        // todo
+    }
+
+    public static void main(String[] args) throws InterruptedException, MQClientException {
+
+        /*
+         * Instantiate with specified consumer group name.
+         */
+        DefaultMQPushConsumer consumer = new DefaultMQPushConsumer("please_rename_unique_group_name_4");
+
+        /*
+         * Specify name server addresses.
+         * <p/>
+         *
+         * Alternatively, you may specify name server addresses via exporting environmental variable: NAMESRV_ADDR
+         * <pre>
+         * {@code
+         * consumer.setNamesrvAddr("name-server1-ip:9876;name-server2-ip:9876");
+         * }
+         * </pre>
+         */
+
+        /*
+         * Specify where to start in case the specified consumer group is a brand new one.
+         */
+        consumer.setConsumeFromWhere(ConsumeFromWhere.CONSUME_FROM_FIRST_OFFSET);
+
+        /*
+         * Subscribe one more more topics to consume.
+         */
+        consumer.subscribe("TopicTest", "*");
+
+        /*
+         *  Register callback to execute on arrival of messages fetched from brokers.
+         */
+        consumer.registerMessageListener(new MessageListenerConcurrently() {
+
+            @Override
+            public ConsumeConcurrentlyStatus consumeMessage(List<MessageExt> msgs,
+                                                            ConsumeConcurrentlyContext context) {
+                System.out.printf("%s Receive New Messages: %s %n", Thread.currentThread().getName(), msgs);
+                return ConsumeConcurrentlyStatus.CONSUME_SUCCESS;
+            }
+        });
+
+        /*
+         *  Launch the consumer instance.
+         */
+        consumer.start();
+
+        System.out.printf("Consumer Started.%n");
+    }
+}

--- a/example/src/main/java/org/apache/rocketmq/example/quickstart/ConsumerOrderly.java
+++ b/example/src/main/java/org/apache/rocketmq/example/quickstart/ConsumerOrderly.java
@@ -60,7 +60,7 @@ public class ConsumerOrderly {
         ArrayList<MessageExt> ret = new ArrayList<MessageExt>();
         PriorityQueue<LabeledMsg> pq = new PriorityQueue<LabeledMsg>(sz, new LabeledMsgComparator());
 
-        System.out.printf("Start sorting. %n");
+//        System.out.printf("Start sorting. %n");
 
         for (int i = 0;i < sz;i++) {
             idx[i] = 1;
@@ -69,7 +69,7 @@ public class ConsumerOrderly {
             pq.add(tmp);
         }
 
-        System.out.printf("Poll first finished. %n");
+//        System.out.printf("Poll first finished. %n");
 
         while (true) {
             LabeledMsg tmp = pq.poll();
@@ -82,7 +82,7 @@ public class ConsumerOrderly {
             pq.add(addToPq);
         }
 
-        System.out.printf("Finish while. %n");
+//        System.out.printf("Finish while. %n");
 
         for (int i = 0;i < sz;i++) {
             int curLen = listLen[i];
@@ -92,13 +92,13 @@ public class ConsumerOrderly {
             }
         }
 
-        System.out.printf("Poll last Finish %n");
+//        System.out.printf("Poll last Finish %n");
 
         while (!pq.isEmpty()) {
             messageNeedToCompare.add(pq.poll().msg);
         }
 
-        System.out.printf("Finish poll rest. %n");
+//        System.out.printf("Finish poll rest. %n");
         return ret;
     }
 
@@ -133,22 +133,24 @@ public class ConsumerOrderly {
             @Override
             public ConsumeConcurrentlyStatus consumeMessage(List<MessageExt> msgs,
                                                             ConsumeConcurrentlyContext context) {
-                System.out.printf("Msg received. %n");
+//                System.out.printf("Msg received. %n");
                 ArrayList<ArrayList<MessageExt>> mps = new ArrayList<ArrayList<MessageExt>>();
                 for (MessageExt msg: msgs) {
                     if (msg.getQueueId() >= mps.size())
                         mps.add(new ArrayList<MessageExt>());
                     mps.get(msg.getQueueId()).add(msg);
                 }
-                System.out.printf("Preparation finished. %n");
+                if (messageNeedToCompare.size() > 0)
+                    mps.add(messageNeedToCompare);
+//                System.out.printf("Preparation finished. %n");
                 List<MessageExt> res = sort(mps);
-                System.out.printf("Sort finished. %n");
+//                System.out.printf("Sort finished. %n");
 
-                System.out.printf("=======%s Start print msg results: %s %n ========", Thread.currentThread().getName(), res);
+//                System.out.printf("=======%s Start print msg results: %s %n ========", Thread.currentThread().getName(), res);
                 for (MessageExt msg: res){
                     System.out.printf("Receive message with timestamp %d %n", msg.getStoreTimestamp());
                 }
-                System.out.printf("=======%s Receive New Messages: %s %n=======", Thread.currentThread().getName(), res);
+//                System.out.printf("=======%s Receive New Messages: %s %n=======", Thread.currentThread().getName(), res);
                 return ConsumeConcurrentlyStatus.CONSUME_SUCCESS;
             }
         });


### PR DESCRIPTION
# 百技273期 脱单发财队
## 第三题 全局排序的Consumer
问题链接 https://github.com/rocketmq-baiji/rocketmq/issues/2
### 赛题重述
实现全局有序的Consumer，从多个Topic消费的消息在时间上排序。
### 赛题难点
1. 用尽量低复杂度的算法解决多个有序队列数据的全局排序问题。
2. mq队列按长度读取，可能存在因分配不均衡，无法获取某个时间前的全部数据，仍有时间更早的数据在mq队列中的问题。
3. 同一个producer如果读写速度过快，在获取时间戳的最小粒度下有多次向不同mq的写入操作，无法判定数据的时间先后顺序。
4. 为鉴权等扩展功能留接口

### 解决方案
![default](https://user-images.githubusercontent.com/22690999/44377999-cdd3f200-a531-11e8-9ecd-805a343a0213.png)

针对难点一，用复杂度O(mlogn)的归并排序和堆排序结合算法解决全局排序问题，其中m表示相关的mq个数，n表示每次从每个mq中抽取的数据数目。

>我们构建Consumerorderly的类，从多个相关mq多次抽取定长有序数据子队列，利用各个子队列中最早的数据构建长度为m的最小堆，每次弹出堆顶时间最早的数据，然后读取该数据所在自队列中下一个数据进堆，直到子序列全部数据出堆。

针对难点二，每次获取数据排序后分为可信队列和留存队列，只输出可信队列，解决分配不均衡问题。
>为了解决分配不均衡导致的每次读取的数据不完全是全局时间最早的前mn个数据，我们根据不同mq读取出的最迟数据(时间记为t)对每次读取的数据排序后进行划分，对于t之前的有序数据称作可信序列，直接输出，对于t之后的数据称为留存数据，无法确定其时间是否比仍在队列中的其他数据时间都早，因此暂时保留，等到下次从mq中拉取数据时再一起归并计算。




### 案列效果
![20180821110400](https://user-images.githubusercontent.com/22690999/44378029-f9ef7300-a531-11e8-9c47-81f2dda7ff98.png)


### 有待解决的问题及思路
针对难点二，数据分布极端不平衡情况下，本算法可能产生留存数据越来越多的情况，可以根据每个mq队列中的留存数据量来确定下一次拉取数据长度。

针对难点三，在producer生成数据的时候根据producerId\生成时间等信息参考雪花算法生成唯一id，当多mq队列归并排序时遇到时间戳相同则比较生成id的大小，决定先后顺序。

针对难点四，在全局排序前可以添加鉴权函数，鉴权通过后开始抽取和排序。

### 反思
第三题是算法题，但是基于JAVA语言实现，由于算法同学技术栈不够全面，没有人熟悉JAVA和相关工程，因此实现缓慢。需要加强自身能力,多多熟悉多种语言开发。
