### PR TITLE
[ISSUE #1]implement a non-persistent broker(第四组)

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/GetNewMessageResult.java
+++ b/store/src/main/java/org/apache/rocketmq/store/GetNewMessageResult.java
@@ -1,0 +1,35 @@
+package org.apache.rocketmq.store;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class GetNewMessageResult {
+    public List<MessageExtBrokerInner> getMessageMapedList() {
+        return messageMapedList;
+    }
+
+    private final List<MessageExtBrokerInner> messageMapedList =
+            new ArrayList<>(100);
+    private long minOffset;
+    private long maxOffset;
+
+    public long getMinOffset() {
+        return minOffset;
+    }
+
+    public void setMinOffset(long minOffset) {
+        this.minOffset = minOffset;
+    }
+
+    public long getMaxOffset() {
+        return maxOffset;
+    }
+
+    public void setMaxOffset(long maxOffset) {
+        this.maxOffset = maxOffset;
+    }
+
+    public void addMessage(final MessageExtBrokerInner message) {
+        this.messageMapedList.add(message);
+    }
+}

--- a/store/src/main/java/org/apache/rocketmq/store/InMemoryMessageStore.java
+++ b/store/src/main/java/org/apache/rocketmq/store/InMemoryMessageStore.java
@@ -1,0 +1,123 @@
+package org.apache.rocketmq.store;
+
+import org.apache.rocketmq.common.message.MessageExt;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Vector;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class InMemoryMessageStore {
+
+    private final ConcurrentMap<String/* topic */, ConcurrentMap<Integer/* queueId */, List<MessageExtBrokerInner>>> messageTable;
+    private final Vector<MessageExt> commitLog;
+    private final int maxListLength = 1000;
+
+    public InMemoryMessageStore(ConcurrentMap<String, ConcurrentMap<Integer, List<MessageExtBrokerInner>>> message, Vector<MessageExt> commitLog) {
+        this.messageTable = message;
+        this.commitLog = commitLog;
+    }
+
+    private void putConsumeQueue(final String topic, final int queueId, final MessageExtBrokerInner message) {
+        ConcurrentMap<Integer/* queueId */, List<MessageExtBrokerInner>> map = this.messageTable.get(topic);
+        if (null == map) {
+            map = new ConcurrentHashMap<Integer/* queueId */, List<MessageExtBrokerInner>>();
+            List<MessageExtBrokerInner> tmpList = new ArrayList<>();
+            tmpList.add(message);
+            map.put(queueId, tmpList);
+            this.messageTable.put(topic, map);
+        } else {
+            map.get(queueId).add(message);
+            if (map.get(queueId).size() > this.maxListLength) {
+                map.get(queueId).remove(0);
+            }
+        }
+
+        this.commitLog.add(message);
+    }
+
+    public PutMessageResult putMessage(MessageExtBrokerInner msg) {
+
+        String topic = msg.getTopic();
+        int queueId = msg.getQueueId();
+        this.putConsumeQueue(topic, queueId, msg);
+
+        return null;
+    }
+
+    public GetNewMessageResult getMessage(String group, String topic, int queueId, long offset, int maxMsgNums) {
+        List<MessageExtBrokerInner> messageList = this.messageTable.get(topic).get(queueId);
+        if (messageList == null) {
+            return null;
+        }
+        if (offset < messageList.get(0).getQueueOffset() || offset >= messageList.get(messageList.size()-1).getQueueOffset()) {
+            return null;
+        }
+
+        int startId = 0;
+        for (int i = 0; i < messageList.size(); i++) {
+            if (offset == messageList.get(i).getQueueOffset()) {
+                startId = i;
+                break;
+            }
+        }
+
+        GetNewMessageResult getMessageResult = new GetNewMessageResult();
+        for (int i = startId; i < offset + maxMsgNums && i < messageList.size(); i++) {
+            getMessageResult.addMessage(messageList.get(i));
+        }
+
+        return getMessageResult;
+    }
+
+    public long getMaxOffsetInQueue(String topic, int queueId) {
+        List<MessageExtBrokerInner> messageList = this.messageTable.get(topic).get(queueId);
+        if (messageList != null) {
+            return messageList.get(messageList.size()-1).getQueueOffset();
+        }
+        return 0;
+    }
+
+    public long getMinOffsetInQueue(String topic, int queueId) {
+        List<MessageExtBrokerInner> messageList = this.messageTable.get(topic).get(queueId);
+        if (messageList != null) {
+            return messageList.get(0).getQueueOffset();
+        }
+        return 0;
+    }
+
+    public long getCommitLogOffsetInQueue(String topic, int queueId, long consumeQueueOffset) {
+        GetNewMessageResult getNewMessageResult = getMessage(null, topic, queueId, consumeQueueOffset, 1);
+        if (null == getNewMessageResult) {
+            return 0;
+        }
+
+        MessageExt messageExt = getNewMessageResult.getMessageMapedList().get(0);
+        if (null == messageExt) {
+            return 0;
+        }
+        for (int i = 0; i < this.commitLog.size(); i++) {
+            if (messageExt.getQueueId() == this.commitLog.get(i).getQueueId()) {
+                return i;
+            }
+        }
+        return 0;
+    }
+
+    public MessageExt lookMessageByOffset(long commitLogOffset) {
+        if (commitLogOffset < 0 || commitLogOffset >= commitLog.size()) {
+            return null;
+        }
+        return commitLog.get((int)commitLogOffset);
+    }
+
+    public SelectMappedBufferResult getCommitLogData(long offset) {
+        return null;
+    }
+
+    public void start() throws Exception { }
+
+    public void shutdown() { }
+
+}


### PR DESCRIPTION
[第四组]

## What is the purpose of the change

Fix issue #1.

## Brief changelog

用来在内存中存储数据的数据结构是 CurrentMap：`private final ConcurrentMap<String/* topic */, ConcurrentMap<Integer/* queueId */, List<MessageExtBrokerInner>>>`
数据存入时，根据topic和queueId可以唯一确定一个List，把message存入到对应的List中。
取数据时，根据topic和queueId和offset从对应的List中取出需要查找的message.