### PR TITLE
第八组 第三题 实现2

### DIFF
--- a/example/src/main/java/org/apache/rocketmq/example/mergeread/OrderedConsumer.java
+++ b/example/src/main/java/org/apache/rocketmq/example/mergeread/OrderedConsumer.java
@@ -1,0 +1,158 @@
+package org.apache.rocketmq.example.mergeread;
+
+import org.apache.rocketmq.client.consumer.DefaultMQPullConsumer;
+import org.apache.rocketmq.client.consumer.PullResult;
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.remoting.exception.RemotingException;
+
+import java.util.ArrayList;
+import java.util.Set;
+
+/**
+ * Created by wkj on 2018/8/21.
+ */
+public class OrderedConsumer {
+    DefaultMQPullConsumer consumer;
+    Set<MessageQueue> mqs;
+    String topic;
+    String tag;
+    String groupName;
+    ArrayList<HeapNode> heap;
+
+    public OrderedConsumer(String groupName, String topic, String tag, String namesvrAddr){
+        this.consumer = new DefaultMQPullConsumer(groupName);
+        consumer.setNamesrvAddr(namesvrAddr);
+        this.topic = topic;
+        this.groupName = groupName;
+        this.tag = tag;
+        heap = new ArrayList<>();
+    }
+
+    public void start() throws MQClientException,MQBrokerException, InterruptedException,RemotingException {
+        this.consumer.start();
+        mqs = consumer.fetchSubscribeMessageQueues(topic);
+        for (MessageQueue mq : mqs) {
+            PullResult pullResult = consumer.pullBlockIfNotFound(mq, tag, 0L, 1);
+            HeapNode heapNode = new HeapNode(pullResult, mq);
+            System.out.println(heapNode.timestamp);
+            heap.add(heapNode);
+        }
+        System.out.println(heap.size());
+        for(int i = (mqs.size()-1)/2; i>=0; i--) {
+            adjustHeap(heap, i);
+        }
+        adjustHeap(heap, 0);
+    }
+
+    public boolean isEmpty(){
+        return heapIsEmpty(heap);
+    }
+
+    private  void adjustHeap(ArrayList<HeapNode> heapTree, int startAt){
+        int leftChildIndex = startAt*2+1;
+        int rightChildIndex = startAt*2+2;
+        int smallerChildIndex = -1;
+
+        HeapNode parent = heapTree.get(startAt);
+        if (leftChildIndex > heapTree.size()-1)
+            return;
+        if (rightChildIndex > heapTree.size()-1)
+            smallerChildIndex = leftChildIndex;
+        else{
+
+            HeapNode leftChild = heapTree.get(leftChildIndex);
+            HeapNode rightChild = heapTree.get(rightChildIndex);
+            if ( leftChild.timestamp < rightChild.timestamp ){
+                smallerChildIndex = leftChildIndex;
+            }else{
+                smallerChildIndex = rightChildIndex;
+            }
+        }
+
+        HeapNode smallerHeapNode = heapTree.get(smallerChildIndex);
+        if (parent.timestamp > smallerHeapNode.timestamp || (parent.isNull && !smallerHeapNode.isNull)) {
+            //exchange parent and child
+            heapTree.set(startAt, smallerHeapNode);
+            heapTree.set(smallerChildIndex, parent);
+            adjustHeap(heapTree, smallerChildIndex);
+        }
+    }
+
+    public MessageExt receive() throws MQClientException,RemotingException,MQBrokerException,InterruptedException, Exception{
+        if (heapIsEmpty(heap)) {
+            throw new Exception("all of queues is empty");
+        }
+        //printHeap(heap);
+        //Step 1: fetch first from heap
+        HeapNode topNode = heap.get(0);
+
+        // consume
+
+        String body = new String(topNode.pullResult.getMsgFoundList().get(0).getBody());
+        MessageExt res  = topNode.pullResult.getMsgFoundList().get(0);
+
+        //printHeap(heap);
+        //Step 2: get Next
+        //System.out.printf("get offset:%d\n", topNode.pullResult.getNextBeginOffset());
+        PullResult pr = consumer.pull(topNode.q, tag, topNode.pullResult.getNextBeginOffset(), 1);
+        topNode.setPullResult(pr);
+
+        //Step 3: adjust Heap
+        adjustHeap(heap,0);
+        return res;
+    }
+
+    public void shutdown(){
+        consumer.shutdown();
+    }
+    private  boolean heapIsEmpty(ArrayList<HeapNode> arr) {
+        for(int i = 0; i<arr.size(); i++){
+            HeapNode hn = arr.get(i);
+            if (!hn.isNull) {
+                return false;
+            }
+        }
+        return true;
+    }
+}
+class HeapNode {
+    PullResult pullResult;
+    MessageQueue q;
+    boolean isNull;
+    long timestamp;
+    public HeapNode(PullResult pr, MessageQueue q){
+        this.pullResult = pr;
+        this.timestamp = pr.getMsgFoundList().get(0).getBornTimestamp();
+        this.q = q;
+    }
+    public void setPullResult(PullResult pullResult) {
+        switch (pullResult.getPullStatus()) {
+            case FOUND:
+                this.pullResult = pullResult;
+                this.timestamp = pullResult.getMsgFoundList().get(0).getBornTimestamp();
+                this.isNull = false;
+                break;
+            case NO_MATCHED_MSG:
+                break;
+            case NO_NEW_MSG:
+                this.isNull = true;
+                this.timestamp = Long.MAX_VALUE;
+                break ;
+            case OFFSET_ILLEGAL:
+                break;
+            default:
+                break;
+        }
+
+    }
+}
+
+class QueueEmptyException extends Exception {
+    private final String errorMessage;
+    QueueEmptyException(String s){
+        errorMessage = s;
+    }
+}

--- a/example/src/main/java/org/apache/rocketmq/example/mergeread/Producer.java
+++ b/example/src/main/java/org/apache/rocketmq/example/mergeread/Producer.java
@@ -1,0 +1,48 @@
+package org.apache.rocketmq.example.mergeread;
+
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.client.producer.DefaultMQProducer;
+import org.apache.rocketmq.client.producer.SendResult;
+import org.apache.rocketmq.common.message.Message;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.remoting.common.RemotingHelper;
+
+import java.util.ArrayList;
+
+/**
+ * Created by wkj on 2018/8/20.
+ */
+public class Producer {
+    public static String groupName = "MergeSort";
+    public static String topic = "Merge";
+    public static String brokerName = "broker-a";
+    static int queueLength = 4;
+    public static void main(String[] args) throws MQClientException, InterruptedException{
+        DefaultMQProducer producer = new DefaultMQProducer(groupName);
+        producer.setNamesrvAddr("localhost:9876");
+        ArrayList<MessageQueue> queues = new ArrayList<>();
+        for (int i= 0; i<queueLength; i++){
+            MessageQueue q = new MessageQueue(topic, brokerName, i);
+            queues.add(q);
+        }
+
+        producer.start();
+        for (int i = 0; i < 5; i++)
+            try {
+                {
+                    Message msg = new Message(topic,
+                            "TagA",
+                            String.valueOf(i),
+                            String.valueOf(i).getBytes(RemotingHelper.DEFAULT_CHARSET));
+                    MessageQueue q = queues.get(i%queueLength);
+                    SendResult sendResult = producer.send(msg, q);
+                    System.out.printf("%s%n", sendResult);
+                }
+
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+
+        producer.shutdown();
+    }
+}

--- a/example/src/main/java/org/apache/rocketmq/example/mergeread/TestConsumer.java
+++ b/example/src/main/java/org/apache/rocketmq/example/mergeread/TestConsumer.java
@@ -1,0 +1,19 @@
+package org.apache.rocketmq.example.mergeread;
+
+import org.apache.rocketmq.common.message.MessageExt;
+
+/**
+ * Created by wkj on 2018/8/21.
+ */
+public class TestConsumer {
+    public static void main(String[] args) throws Exception{
+        OrderedConsumer oc = new OrderedConsumer("MergeSort", "Merge", "TagA","localhost:9876");
+        oc.start();
+        while(!oc.isEmpty()){
+            MessageExt msg = oc.receive();
+            String msgBody = new String(msg.getBody());
+            long ts = msg.getBornTimestamp();
+            System.out.printf("ts:%d %s\n", ts, msgBody);
+        }
+    }
+}


### PR DESCRIPTION
## What is the purpose of the change

添加从多个队列顺序读取的OrderedConsumer

## Brief changelog

将多个队列的头元素链接成为一个小顶堆，每次receive时读取堆顶元素，然后调整堆，实现从多个队列的顺序读取。

按照borntimestamp排序，如果一个队列没有元素可读，该队列的头元素时间戳被设为无穷大。当重新获取到元素时，需要重新调整堆。

所有队列均为空时，抛出异常

