### PR TITLE
Create BufferMessageStore Group 9

### DIFF
--- a/store/src/main/java/org/apache/rocketmq/store/BufferMessageStore
+++ b/store/src/main/java/org/apache/rocketmq/store/BufferMessageStore
@@ -1,11 +1,14 @@
 package org.apache.rocketmq.store;
 
+import org.apache.rocketmq.common.BrokerConfig;
 import org.apache.rocketmq.common.constant.LoggerName;
 import org.apache.rocketmq.common.message.MessageExt;
 import org.apache.rocketmq.common.message.MessageExtBatch;
 import org.apache.rocketmq.logging.InternalLogger;
 import org.apache.rocketmq.logging.InternalLoggerFactory;
+import org.apache.rocketmq.store.config.MessageStoreConfig;
 import org.apache.rocketmq.store.config.StorePathConfigHelper;
+import org.apache.rocketmq.store.stats.BrokerStatsManager;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
@@ -15,7 +18,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
-public class BufferMessageStore implements MessageStore {
+public class BufferMessageStore extends DefaultMessageStore {
     private static final InternalLogger log = InternalLoggerFactory.getLogger(LoggerName.STORE_LOGGER_NAME);
 
 /**
@@ -44,7 +47,8 @@ public class BufferMessageStore implements MessageStore {
     //factory
 
 
-    public BufferMessageStore(ConcurrentMap<String, ConcurrentMap<Integer, ConsumeQueue>> consumeQueueTable, ByteBuffer buffer, int size, boolean shutdown, int position, int mark, int limit, int writeOffset, int writeLength) {
+    public BufferMessageStore(MessageStoreConfig messageStoreConfig, BrokerStatsManager brokerStatsManager, MessageArrivingListener messageArrivingListener, BrokerConfig brokerConfig, ConcurrentMap<String, ConcurrentMap<Integer, ConsumeQueue>> consumeQueueTable, ByteBuffer buffer, int size, boolean shutdown, int position, int mark, int limit, int writeOffset, int writeLength) throws IOException {
+        super(messageStoreConfig, brokerStatsManager, messageArrivingListener, brokerConfig);
         this.consumeQueueTable = consumeQueueTable;
         this.buffer = buffer;
         this.size = size;
@@ -76,7 +80,7 @@ public class BufferMessageStore implements MessageStore {
 
     }
 
-    public ByteBuffer putMessage(MessageExtBrokerInner msg) {
+    public PutMessageResult putMessage(MessageExtBrokerInner msg) {
         if (this.shutdown) {
             log.warn("message store has shutdown, so putMessage is forbidden");
         }
@@ -85,10 +89,10 @@ public class BufferMessageStore implements MessageStore {
             log.warn("buffer is full");
         }
 
-        buffer = buffer.wrap(msg.toString().getBytes(), writeOffset, msg.toString().getBytes().length;
+        buffer = buffer.wrap(msg.toString().getBytes(), writeOffset, msg.toString().getBytes().length);
         writeOffset += msg.toString().getBytes().length;
 
-        return buffer;
+        return new PutMessageResult(PutMessageStatus.PUT_OK, null);
     }
 
     public ByteBuffer getMessage(ByteBuffer buffer, int offset, int length) {
@@ -97,17 +101,13 @@ public class BufferMessageStore implements MessageStore {
         return result;
     }
 
+    @Override
+    public void destroy() {
 
-
+    }
 
     @Override
     public long getMaxOffsetInQueue(String topic, int queueId) {
-        ConsumeQueue logic = this.findConsumeQueue(topic, queueId);
-        if (logic != null) {
-            long offset = logic.getMaxOffsetInQueue();
-            return offset;
-        }
-
         return 0;
     }
 
@@ -125,4 +125,6 @@ public class BufferMessageStore implements MessageStore {
     public boolean load() {
         return true;
     }
+
+
 }

--- a/store/src/main/java/org/apache/rocketmq/store/BufferMessageStore
+++ b/store/src/main/java/org/apache/rocketmq/store/BufferMessageStore
@@ -1,0 +1,128 @@
+package org.apache.rocketmq.store;
+
+import org.apache.rocketmq.common.constant.LoggerName;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.common.message.MessageExtBatch;
+import org.apache.rocketmq.logging.InternalLogger;
+import org.apache.rocketmq.logging.InternalLoggerFactory;
+import org.apache.rocketmq.store.config.StorePathConfigHelper;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+
+public class BufferMessageStore implements MessageStore {
+    private static final InternalLogger log = InternalLoggerFactory.getLogger(LoggerName.STORE_LOGGER_NAME);
+
+/**
+ * ii.	可以只实现最基本的接口
+ * 1.	start
+ * 2.	shutdown
+ * 3.	putMessage
+ * 4.	getMessage
+ * 5.	getMaxOffsetInQueue
+ * 6.	getMinOffsetInQueue
+ * 7.	getCommitLogOffsetInQueue
+ * 8.	lookMessagByOffset
+ * 9.	getCommitLogData
+ */
+    private final ConcurrentMap<String/* topic */, ConcurrentMap<Integer/* queueId */, ConsumeQueue>> consumeQueueTable;
+    private ByteBuffer buffer;
+    private final int size;
+    private boolean shutdown;
+    private final int position;
+    private final int mark;
+    private final int limit;
+
+    private int writeOffset;
+    private int writeLength;
+
+    //factory
+
+
+    public BufferMessageStore(ConcurrentMap<String, ConcurrentMap<Integer, ConsumeQueue>> consumeQueueTable, ByteBuffer buffer, int size, boolean shutdown, int position, int mark, int limit, int writeOffset, int writeLength) {
+        this.consumeQueueTable = consumeQueueTable;
+        this.buffer = buffer;
+        this.size = size;
+        this.shutdown = shutdown;
+        this.position = position;
+        this.mark = mark;
+        this.limit = limit;
+        this.writeOffset = writeOffset;
+        this.writeLength = writeLength;
+    }
+
+    /**
+     * @throws IOException
+     */
+
+    @Override
+    public void start() throws Exception {
+        buffer = ByteBuffer.allocateDirect(size);
+
+        this.shutdown = false;
+    }
+
+    @Override
+    public void shutdown() {
+        if (!shutdown){
+            this.shutdown = true;
+            Runtime.getRuntime().freeMemory();
+        }
+
+    }
+
+    public ByteBuffer putMessage(MessageExtBrokerInner msg) {
+        if (this.shutdown) {
+            log.warn("message store has shutdown, so putMessage is forbidden");
+        }
+
+        if (position >= size){
+            log.warn("buffer is full");
+        }
+
+        buffer = buffer.wrap(msg.toString().getBytes(), writeOffset, msg.toString().getBytes().length;
+        writeOffset += msg.toString().getBytes().length;
+
+        return buffer;
+    }
+
+    public ByteBuffer getMessage(ByteBuffer buffer, int offset, int length) {
+        byte[] temp = buffer.array();
+        ByteBuffer result = buffer.get(temp,offset,length);
+        return result;
+    }
+
+
+
+
+    @Override
+    public long getMaxOffsetInQueue(String topic, int queueId) {
+        ConsumeQueue logic = this.findConsumeQueue(topic, queueId);
+        if (logic != null) {
+            long offset = logic.getMaxOffsetInQueue();
+            return offset;
+        }
+
+        return 0;
+    }
+
+
+    @Override
+    public long getMinOffsetInQueue(String topic, int queueId) {
+        return 0;
+    }
+
+    @Override
+    public MessageExt lookMessageByOffset(long commitLogOffset) {
+        return null;
+    }
+
+    public boolean load() {
+        return true;
+    }
+}


### PR DESCRIPTION
ISSUE https://github.com/rocketmq-baiji/rocketmq/issues/1
## What is the purpose of the change

实现一个非持久化的broker

## 思路
考虑队列堆积等情况，我们采用堆外内存.
1.  Start: 采用ByteBuffer.allocatDirect()分配内存
2.  Shutdown：采用Runtime.getRuntime().freeMemory();释放空间
3.  putMessage：采用wrap(ByteBuffer, int offset, int length)进行存储，并记录更新偏移位置offset
4.  getMessage :采用get(ByteBuffer, int offset, int length)进行定向读取缓存数据。

## Brief changelog

add a java class

## Verifying this change

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).