### PR TITLE
[#2][Group 1]Add: ordered MQ Pull consumer

### DIFF
--- a/client/src/main/java/org/apache/rocketmq/client/consumer/OrderedMQPullConsumer.java
+++ b/client/src/main/java/org/apache/rocketmq/client/consumer/OrderedMQPullConsumer.java
@@ -1,0 +1,168 @@
+package org.apache.rocketmq.client.consumer;
+
+import org.apache.rocketmq.client.exception.MQBrokerException;
+import org.apache.rocketmq.client.exception.MQClientException;
+import org.apache.rocketmq.common.message.MessageExt;
+import org.apache.rocketmq.common.message.MessageQueue;
+import org.apache.rocketmq.remoting.RPCHook;
+import org.apache.rocketmq.remoting.exception.RemotingException;
+
+import java.util.*;
+
+public class OrderedMQPullConsumer extends DefaultMQPullConsumer {
+    /**
+     * 每个队列每次拉取的条数
+     */
+    private static final int EACH_QUEUE_PULL_NUM = 10;
+
+    private int eachQueuePullNum = EACH_QUEUE_PULL_NUM;
+
+    public OrderedMQPullConsumer() {
+    }
+
+    public OrderedMQPullConsumer(String consumerGroup, RPCHook rpcHook) {
+        super(consumerGroup, rpcHook);
+    }
+
+    public OrderedMQPullConsumer(String consumerGroup) {
+        super(consumerGroup);
+    }
+
+    public OrderedMQPullConsumer(RPCHook rpcHook) {
+        super(rpcHook);
+    }
+
+    /**
+     * 设置每个队列每次拉取的条数
+     *
+     * @param eachQueuePullNum 条数
+     */
+    public void setEachQueuePullNum(int eachQueuePullNum) {
+        this.eachQueuePullNum = eachQueuePullNum;
+    }
+
+    /**
+     * 拉取消息
+     *
+     * @param topic         话题
+     * @param subExpression 子查询表达式
+     * @param maxNums       最大数量
+     * @return 拉取结果
+     * @throws MQClientException
+     * @throws RemotingException
+     * @throws MQBrokerException
+     * @throws InterruptedException
+     */
+    public PullResult pull(String topic, String subExpression, int maxNums)
+            throws MQClientException, RemotingException, MQBrokerException, InterruptedException {
+        //取出话题下的所有队列
+        Set<MessageQueue> messageQueues = fetchSubscribeMessageQueues(topic);
+        HashMap<Integer, Long> offsetMap = new HashMap<>(messageQueues.size());
+        //包装类的有序集合，按照每个队列的第一条消息进行排序
+        TreeSet<Wrapper> sortedWrappers = new TreeSet<>();
+        for (MessageQueue mq : messageQueues) {
+            //遍历消息队列，把每个队列的偏移量取出来，并且按照偏移量去取一次消息，封装成包装类添加到包装类的队列中
+            offsetMap.put(mq.getQueueId(), fetchConsumeOffset(mq, true));
+            Wrapper wrapper = pullByQueue(mq, subExpression, offsetMap, EACH_QUEUE_PULL_NUM);
+            if (wrapper != null) {
+                sortedWrappers.add(wrapper);
+            }
+        }
+        //消息结果列表
+        List<MessageExt> resultMessages = new ArrayList<>();
+        while (resultMessages.size() < maxNums) {
+            //从队列中取出一个包装队列
+            Wrapper wrapper = sortedWrappers.pollFirst();
+            if (wrapper == null) {
+                break;
+            }
+            //从包装队列中取出一条消息，再按照新的队首消息进行排序
+            MessageExt messageExt = wrapper.poll();
+            if (messageExt == null) {
+                //如果当前队列已为空，则再去拉取消息
+                wrapper = pullByQueue(wrapper.messageQueue, subExpression, offsetMap, EACH_QUEUE_PULL_NUM);
+                if (wrapper != null) {
+                    sortedWrappers.add(wrapper);
+                }
+            } else {
+                resultMessages.add(messageExt);
+                sortedWrappers.add(wrapper);
+            }
+        }
+        //返回最终的结果，这里 offset 暂时没有进行处理
+        if (resultMessages.isEmpty()) {
+            return new PullResult(PullStatus.NO_NEW_MSG, 0, 0, 0, resultMessages);
+        }
+        return new PullResult(PullStatus.FOUND, 0, 0, 0, resultMessages);
+    }
+
+    /**
+     * 从队列中拉取一次消息
+     *
+     * @param messageQueue  消息队列
+     * @param subExpression 子查询表达式
+     * @param offsetMap     每个队列的偏移量
+     * @param num           拉取数目
+     * @return
+     * @throws MQClientException
+     * @throws RemotingException
+     * @throws MQBrokerException
+     * @throws InterruptedException
+     */
+    private Wrapper pullByQueue(MessageQueue messageQueue, String subExpression, HashMap<Integer, Long> offsetMap,
+                                int num)
+            throws MQClientException, RemotingException, MQBrokerException, InterruptedException {
+        Long offset = offsetMap.remove(messageQueue.getQueueId());
+        if (offset == null) {
+            return null;
+        }
+        PullResult pullResult = pull(messageQueue, subExpression, offset, num);
+        if (pullResult.getPullStatus() != PullStatus.FOUND) {
+            return null;
+        }
+        offsetMap.put(messageQueue.getQueueId(), pullResult.getNextBeginOffset());
+        return new Wrapper(messageQueue, new LinkedList<>(pullResult.getMsgFoundList()));
+    }
+
+    /**
+     * 队列的包装类
+     */
+    static class Wrapper implements Comparable<Wrapper> {
+        /**
+         * 消息队列对象
+         */
+        MessageQueue messageQueue;
+        /**
+         * 消息列表
+         */
+        LinkedList<MessageExt> messageList;
+
+        Wrapper(MessageQueue messageQueue, LinkedList<MessageExt> messageList) {
+            this.messageQueue = messageQueue;
+            this.messageList = messageList;
+        }
+
+        /**
+         * 取出一条消息
+         *
+         * @return 消息
+         */
+        MessageExt poll() {
+            return messageList.poll();
+        }
+
+        /**
+         * 用于队列的比较方法，按照每个队列的第一条消息进行排序
+         *
+         * @param that 另一个队列的包装类
+         * @return 大小值
+         */
+        @Override
+        public int compareTo(Wrapper that) {
+            if (this.messageList.isEmpty()) {
+                return that.messageList.isEmpty() ? 0 : 1;
+            }
+            return (int) (this.messageList.get(0).getBornTimestamp() - that.messageList.get(0).getBornTimestamp());
+        }
+    }
+}


### PR DESCRIPTION
# What is the purpose of the change
添加 OrderedMQPullConsumer 类，实现对多个消息队列进行排序，获取前 `k` 早的信息。

# Brief changelog
* 对每个 `MessageQueue` 维护一个本地缓冲区，用于减少网络交互次数，提高性能。
* 用数据结构 `TreeSet` 维护所有 `MessageQueue`，按照缓冲区里第一条信息的时间戳进行排序。
* 每次从数据结构中取出排在第一位的 `MessageQueue`，消费其第一条信息，并将缓冲区中下一条信息的时间戳作为该 `MessageQueue` 的关键字重新插入数据结构中。
* 特别地，若缓冲区为空，则需要重新通过网络拉取该 `MessageQueue` 后若干条信息存入缓冲区中。

## Verifying this change

Verify OK

Follow this checklist to help us incorporate your contribution quickly and easily. Notice, `it would be helpful if you could finish the following 5 checklist(the last one is not necessary)before request the community to review your PR`.

- [x] Make sure there is a [Github issue](https://github.com/apache/rocketmq/issues) filed for the change (usually before you start working on it). Trivial changes like typos do not require a Github issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue. 
- [x] Format the pull request title like `[ISSUE #123] Fix UnknownException when host config not exist`. Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Write necessary unit-test(over 80% coverage) to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add integration-test in [test module](https://github.com/apache/rocketmq/tree/master/test).
- [x] Run `mvn -B clean apache-rat:check findbugs:findbugs checkstyle:checkstyle` to make sure basic checks pass. Run `mvn clean install -DskipITs` to make sure unit-test pass. Run `mvn clean test-compile failsafe:integration-test`  to make sure integration-test pass.
- [ ] If this contribution is large, please file an [Apache Individual Contributor License Agreement](http://www.apache.org/licenses/#clas).
